### PR TITLE
Enable multitap (MultiPlayer5) when a button is pressed on controller 3,4, or 5

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -179,6 +179,7 @@ uint32 S9xReadJoypad(int which1)
 
 void retro_set_controller_port_device(unsigned in_port, unsigned device)
 {
+	// Do nothing, evidently this is not normally called
 }
 
 void retro_get_system_av_info(struct retro_system_av_info *info)
@@ -215,9 +216,10 @@ static void snes_init (void)
 	Settings.DisableMasterVolume = FALSE;
 	Settings.Mouse = FALSE;
 	Settings.SuperScope = FALSE;
+
+	// Initialize to no multi-tap
 	Settings.MultiPlayer5 = FALSE;
-	//	Settings.ControllerOption = SNES_MULTIPLAYER5;
-	Settings.ControllerOption = 0;
+	Settings.ControllerOption = SNES_JOYPAD;
 	
 	Settings.ForceTransparency = FALSE;
 	Settings.Transparency = TRUE;
@@ -353,7 +355,18 @@ static void report_buttons (void)
 		for (j = 0; j <= RETRO_DEVICE_ID_JOYPAD_R; j++)
 		{
 			if (input_cb(i, RETRO_DEVICE_JOYPAD, 0, j))
+			{
 				joys[i] |= (1 << (15 - j));
+				
+				// DJW If a button was pressed on controller 3 or 4 then we
+				// want to enable the multitap
+				if(i > 1 && !Settings.MultiPlayer5)
+				{
+					Settings.MultiPlayer5 = TRUE;
+					Settings.ControllerOption = SNES_MULTIPLAYER5;
+					IPPU.Controller = SNES_MULTIPLAYER5;
+				}
+			}
 			else
 				joys[i] &= ~(1 << (15 - j));
 		}

--- a/src/display.h
+++ b/src/display.h
@@ -64,7 +64,7 @@ void S9xParseDisplayArg (char **argv, int &index, int argc);
 void S9xToggleSoundChannel (int channel);
 void S9xSetInfoString (const char *string);
 int S9xMinCommandLineArgs ();
-void S9xNextController ();
+//void S9xNextController ();
 bool8_32 S9xLoadROMImage (const char *string);
 const char *S9xSelectFilename (const char *def, const char *dir,
 			       const char *ext, const char *title);

--- a/src/ppu.cpp
+++ b/src/ppu.cpp
@@ -1128,12 +1128,7 @@ void S9xResetPPU()
 	IPPU.Mouse[0] = IPPU.Mouse[1] = 0;
 	IPPU.PrevMouseX[0] = IPPU.PrevMouseX[1] = 256 / 2;
 	IPPU.PrevMouseY[0] = IPPU.PrevMouseY[1] = 224 / 2;
-
-	if (Settings.ControllerOption == 0)
-		IPPU.Controller = SNES_MAX_CONTROLLER_OPTIONS - 1;
-	else
-		IPPU.Controller = Settings.ControllerOption - 1;
-	S9xNextController();
+	IPPU.Controller = Settings.ControllerOption;
 
 	for (c = 0; c < 2; c++)
 		memset(& IPPU.Clip[c], 0, sizeof(struct ClipData));
@@ -1270,6 +1265,9 @@ void ProcessSuperScope()
 	}
 }
 
+// DJW this function is unecessary as far as I can tell,
+// perhaps it was called externally in an old version of SNES9x
+/*
 void S9xNextController()
 {
 	switch (IPPU.Controller)
@@ -1305,7 +1303,7 @@ void S9xNextController()
 			IPPU.Controller = SNES_JOYPAD;
 			break;
 	}
-}
+	}*/
 
 void S9xUpdateJoypads()
 {
@@ -1362,6 +1360,7 @@ void S9xUpdateJoypads()
 	if (Settings.SuperScopeMaster)
 		ProcessSuperScope();
 
+	// Auto joypad code
 	if (Memory.FillRAM[0x4200] & 1)
 	{
 		PPU.Joypad1ButtonReadPos = 16;


### PR DESCRIPTION
I wanted to add support for multitap/multiplayer games. However, due to the libreatro/retroarch interface there is evidently no way to query retroarch for the number of controllers that are connected. There is one function retro_set_controller_port_device defined (and empty) in libretro/libretro.cpp but evidently this is not ever being called by retroarch. So I made a change so that by default the multitap is disabled (since I've heard that some 1-2 player games will not work propertly if the multitap is connected/enabled, though I don't know which games these are exactly to test) but it becomes enabled if a button is pressed controller 3, 4, or 5. Before, the code to support the multitap was there but always disabled.